### PR TITLE
Bug fix -- now the right interval tuple is emitted

### DIFF
--- a/3vv_sonorities.py
+++ b/3vv_sonorities.py
@@ -47,7 +47,7 @@ def intervalsfromlines(lines):
     """
     for filename, filelineno, line in lines:
         if filelineno >= 4:
-            intvs = line.strip().split(',')[1:]
+            intvs = line.strip().split(',')[2:]
             if any(x == 'Rest' for x in intvs):
                 # This should always yield just one interval or no intervals.
                 intv = tuple(x for x in intvs if x != 'Rest')


### PR DESCRIPTION
Used to do first two intervals, now does last two. Also renamed according to new conventions.
